### PR TITLE
Fixed prototype pollution

### DIFF
--- a/tiny-conf.js
+++ b/tiny-conf.js
@@ -44,6 +44,9 @@ Store.prototype = {
    * @return {boolean} true if set; false otherwise
    */
   set: function (key, val) {
+    if (key.includes('__proto__') || key.includes('prototype') || key.includes('constructor')){
+      return undefined;
+    }
     if (val === undefined) {
       val = key;
       key = null;


### PR DESCRIPTION
### Description
This package was vulnerable to ```Prototype Pollution``` via the ```set``` function.
Bug reference from snyk: https://snyk.io/vuln/SNYK-JS-TINYCONF-598792

### POC
```
const tinyConf = require('tiny-conf'); 
tinyConf.set('__proto__.polluted', true); 
console.log(polluted); //true 
```

Fixed prototype pollution by filtering the keywords causing the vulnerability. ```__proto__```,```prototype``` and ```constructor```. 

### POF
Running the POC will return the ```polluted``` variable as ```not defined```